### PR TITLE
Remove unused ping handling

### DIFF
--- a/FleshWound_Comm.lua
+++ b/FleshWound_Comm.lua
@@ -2,7 +2,7 @@ local addonName, addonTable = ...
 local Comm = {}
 addonTable.Comm = Comm
 Comm.PREFIX = "FW"
-Comm.PING_TIMEOUT = 5
+Comm.REQUEST_TIMEOUT = 5
 local AceSerializer = LibStub("AceSerializer-3.0")
 local LibDeflate = LibStub("LibDeflate", true)
 local CHANNEL_NAME = "FleshWoundComm"
@@ -25,7 +25,7 @@ function Comm:RequestProfile(targetPlayer)
         if registry then
             registry:SendQuery()
         end
-        C_Timer.After(self.PING_TIMEOUT, function()
+        C_Timer.After(self.REQUEST_TIMEOUT, function()
             if registry and registry:IsUserOnline(targetPlayer) then
                 ChatThrottleLib:SendAddonMessage("NORMAL", self.PREFIX, "REQUEST_PROFILE", "WHISPER", targetPlayer)
             end
@@ -149,8 +149,7 @@ end
 -- Addon Message Handling
 --------------------------------------------------------------------------------
 
---- Processes incoming addon messages.
--- Handles "PING", "PONG", "REQUEST_PROFILE", and "PROFILE_DATA" commands.
+--- Processes incoming addon messages for "REQUEST_PROFILE" and "PROFILE_DATA" commands.
 -- @param prefixMsg string The message prefix.
 -- @param msg string The content of the message.
 -- @param channel string The channel over which the message was received.

--- a/FleshWound_TargetPopup.lua
+++ b/FleshWound_TargetPopup.lua
@@ -6,7 +6,6 @@ local CONSTANTS = {
     FRAME_SIZE = { WIDTH = 220, HEIGHT = 80 },
     QUERY_RETRY_DURATION = 10,
     FRAME_POSITION = { ANCHOR = "BOTTOMRIGHT", X_OFFSET = -50, Y_OFFSET = 200 },
-    PING_TIMEOUT = 5,
     BACKDROP = {
         GOLD_BG = "Interface\\DialogFrame\\UI-DialogBox-Gold-Background",
         GOLD_BORDER = "Interface\\DialogFrame\\UI-DialogBox-Gold-Border",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - **Wound Sharing**
     - Share your character's injuries with other players.
     - View other players' injuries for more informed and immersive roleplay scenarios.
+    - Communication relies on a query/hello system and does not use ping/pong messages.
 
 - **Localization**
     - Available in English and French. More languages to come!


### PR DESCRIPTION
## Summary
- rename `PING_TIMEOUT` variable to `REQUEST_TIMEOUT`
- drop `PING_TIMEOUT` constant from TargetPopup
- clarify addon message handling comment
- note lack of ping/pong in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d35c84d48832b9941c320bc6a7a0d